### PR TITLE
Kubernetes/monitoring

### DIFF
--- a/kubernetes-monitoring/README.md
+++ b/kubernetes-monitoring/README.md
@@ -1,0 +1,29 @@
+##### Устанавливаем prometheus-operator/kube-prometheus
+```
+kubectl create ns monitoring
+helm repo add choerodon https://openchart.choerodon.com.cn/choerodon/c7n
+helm repo update
+helm upgrade --install prometheus choerodon/kube-prometheus --version 9.3.1 -n monitoring \
+ --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+ --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false
+```
+prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false - зачем это нужно написано [тут](https://hub.helm.sh/charts/choerodon/kube-prometheus)
+
+prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false - так зачем это написано [тут](https://hub.helm.sh/charts/choerodon/kube-prometheus)
+
+
+##### Создаем кастомный образ nginx с nginx-exporter и запускаем его
+```
+kubectl create ns nginx
+kubectl apply -f nginx.yaml
+```
+
+##### Запускаем servicemonitor
+```
+kubectl apply -f ServiceMonitor.yaml
+```
+
+##### Данные можно посмотреть
+```
+kubectl -n monitoring port-forward --address 0.0.0.0 pod/prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
+kubectl -n monitoring port-forward --address 0.0.0.0 pod/prometheus-grafana-5558455c66-9qw5l 3000:3000

--- a/kubernetes-monitoring/ServiceMonitor.yaml
+++ b/kubernetes-monitoring/ServiceMonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx
+  namespace: nginx
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  namespaceSelector:
+    matchNames:
+      - nginx
+  endpoints:
+    - port: metrics
+      path: /metrics

--- a/kubernetes-monitoring/nginx.yaml
+++ b/kubernetes-monitoring/nginx.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: app
+          image: nginx
+          ports:
+            - name: nginx
+              containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+        - name: nginx-exporter
+          image: nginx/nginx-prometheus-exporter
+          args: ['-nginx.scrape-uri', 'http://localhost:80/basic_status']
+          ports:
+            - name: metrics
+              containerPort: 9113
+      volumes:
+        - name: config
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: config-nginx
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-nginx
+  namespace: nginx
+  labels:
+    app: nginx
+data:
+  config.conf: |
+    server {
+      listen       80;
+      listen  [::]:80;
+      server_name  localhost;
+      location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+      location = /basic_status {
+        stub_status;
+        }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx
+  labels:
+    app: nginx
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+    - name: metrics
+      protocol: TCP
+      port: 9113


### PR DESCRIPTION
##### Устанавливаем prometheus-operator/kube-prometheus
```
kubectl create ns monitoring
helm repo add choerodon https://openchart.choerodon.com.cn/choerodon/c7n
helm repo update
helm upgrade --install prometheus choerodon/kube-prometheus --version 9.3.1 -n monitoring \
 --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
 --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false
```
prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false - зачем это нужно написано [тут](https://hub.helm.sh/charts/choerodon/kube-prometheus)

prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false - так зачем это написано [тут](https://hub.helm.sh/charts/choerodon/kube-prometheus)


##### Создаем кастомный образ nginx с nginx-exporter и запускаем его
```
kubectl create ns nginx
kubectl apply -f nginx.yaml
```

##### Запускаем servicemonitor
```
kubectl apply -f ServiceMonitor.yaml
```

##### Данные можно посмотреть
```
kubectl -n monitoring port-forward --address 0.0.0.0 pod/prometheus-prometheus-kube-prometheus-prometheus-0 9090:9090
kubectl -n monitoring port-forward --address 0.0.0.0 pod/prometheus-grafana-5558455c66-9qw5l 3000:3000